### PR TITLE
:bug: typo in manage.py

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -16,5 +16,5 @@ if __name__ == "__main__":
             "Couldn't import Django. Are you sure it's installed and "
             "available on your PYTHONPATH environment variable? Did you "
             "forget to activate a virtual environment?"
-        ) from exc
+        )
     execute_from_command_line(sys.argv)


### PR DESCRIPTION
`manage.py` did not run, due to a typo in the ImportError line.